### PR TITLE
Updated target framework to .NET Core 3.1 from .NET Core 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ _[Ss]cripts
 *.nupkg
 *.ncrunchsolution
 *.dot[Cc]over
+*.vs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ As members of the .Net guild, you will be working through the challenges of Twil
 
 We assume that before you begin, you will have [.Net Core](https://dotnet.microsoft.com/download) installed on your system and available at the command line.
 
+At the time of writing - the following .Net Core framework version is required:
+    - 3.1.x
+
 Before you can run this project, you will need to set three system environment variables.  These are:
 
 * `TWILIO_ACCOUNT_SID` : Your Twilio "account SID" - it's like your username for the Twilio API.  This and the auth token (below) can be found [in the console](https://www.twilio.com/console).

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace starter_dotnet_core
 {
@@ -18,11 +18,11 @@ namespace starter_dotnet_core
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -35,13 +35,14 @@ namespace starter_dotnet_core
                 app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
-            app.UseMvc(routes =>
+            app.UseRouting();
+
+            app.UseEndpoints(ep =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                ep.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
         }
     }

--- a/starter-dotnet-core-mvc.csproj
+++ b/starter-dotnet-core-mvc.csproj
@@ -1,15 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>starter_dotnet_core</RootNamespace>
   </PropertyGroup>
 
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="twilio" Version="5.31.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated target framework to .NET Core 3.1 from .NET Core 2.2 as this will be reaching End Of Life in December 2020

Followed/Applied the upgrade steps found at https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio & https://docs.microsoft.com/en-us/aspnet/core/migration/30-to-31?view=aspnetcore-3.1&tabs=visual-studio
Update to .gitignore to ignore the .VS folder and contents.
Updated README.md to explicitly state that framework version 3.1.x is required
Verified the program still runs as expected.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
