### PR TITLE
Removed the HTTPS redirect middleware.

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -35,7 +35,7 @@ namespace starter_dotnet_core
                 app.UseHsts();
             }
 
-            app.UseHttpsRedirection();
+            // app.UseHttpsRedirection(); // TwilioQuest expects to send via HTTP.
             app.UseStaticFiles();
 
             app.UseRouting();


### PR DESCRIPTION
TwilioQuest defaults to an HTTP connection in its example text within **Basic Training: Local Twilio Dev Environment**. While HTTPS is generally recommended as a best practice, in this case it only serves as a way to (silently) frustrate a new developer trying to work their way through TwilioQuest.

As such, I have commented out the HTTP redirection middleware used by .NET Core. It remains in place, in case a new user wants to dabble with secure connectivity, but it's unlikely that _most_ users will wish this to be the case.

This directly addresses #5, but doesn't mess with project configuration (like the other pull request addressing this issue). 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [✔] I acknowledge that all my contributions will be made under the project's license.
